### PR TITLE
Update for WinPixEventRuntime

### DIFF
--- a/Samples/D3D12nBodyGravity/readme.md
+++ b/Samples/D3D12nBodyGravity/readme.md
@@ -16,6 +16,7 @@ The main differences are:
 * Windows 10, 64-bit
 * A Direct3D 12 compatible GPU
 * Screen resolution must be 1920x1080 or higher. The sample will run in 1600×1050 pixel resolution.
+* The WinPixEventRuntime is required to build, this can be installed by following these instructions: https://devblogs.microsoft.com/pix/winpixeventruntime/
 
 ## Notes
 

--- a/Samples/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/D3D12nBodyGravity/src/stdafx.h
@@ -26,7 +26,7 @@
 #include <D3Dcompiler.h>
 #include <DirectXMath.h>
 #include "d3dx12.h"
-#include <pix.h>
+#include <pix3.h>
 
 #include <wrl.h>
 #include <vector>


### PR DESCRIPTION
The PIX event runtime moved out of the Windows SDK and into a NuGet                                                                                                                                                                                                      package.  This change updates the requirements with a link to                                                                                                                                                                                                            installation instructions for the WinPixEventRuntime and updates the                                                                                                                                                                                                     PIX header included to pix3.h as required by the new package.
