### PR TITLE
Fix compilation errors with VS2022

### DIFF
--- a/Samples/D3D12nBodyGravity/src/stdafx.h
+++ b/Samples/D3D12nBodyGravity/src/stdafx.h
@@ -29,5 +29,6 @@
 #include <pix3.h>
 
 #include <wrl.h>
+#include <string>
 #include <vector>
 #include <shellapi.h>


### PR DESCRIPTION
The original code doesn't include `<string>`, which will lead to compilation errors:
 
```
GPUOpen-LibrariesAndSDKs\nBodyD3D12\Samples\D3D12nBodyGravity\src\DXSample.h(20,41): error C2039: 'wstring': is not a member of 'std'
```